### PR TITLE
Configuration Block

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,26 @@ mount Thincloud::Authentication::Engine => "/auth", as: "auth_engine"
 Using the example above, you may now login or signup at [http://lvh.me:3000/auth](http://lvh.me:3000/auth).
 
 
+## Configuration
+
+The `Thincloud::Authentication` module accepts a `configure` block with options to specify additional provider strategies. Add a key to the `providers` hash with the name of the strategy, followed by additional options for `scopes` and `fields` as needed. Additionally, you will need to provide environment variables (prefixed with the provider name), with the `consumer_key` and `consumer_secret` values from your OAuth provider.
+
+To enable the [LinkedIn](https://github.com/skorks/omniauth-linkedin) provider:
+
+* Provide values for `ENV["LINKEDIN_CONSUMER_KEY"]` and `ENV["LINKEDIN_CONSUMER_SECRET"]`
+* Add the file `config/initializers/thincloud_authentication.rb` with the following contents:
+
+```ruby
+Thincloud::Authentication.configure do |config|
+  config.providers[:linkedin] = {
+    scopes: "r_emailaddress r_basicprofile",
+    fields: ["id", "email-address", "first-name", "last-name", "headline",
+             "industry", "picture-url", "location", "public-profile-url"]
+  }
+end
+```
+
+
 ### Vanity Routes
 
 If you want to customize the routes (remove the `/auth` prefix), you may add the following to your `config/routes.rb` file:

--- a/lib/thincloud-authentication.rb
+++ b/lib/thincloud-authentication.rb
@@ -1,3 +1,4 @@
+require "thincloud/authentication/configuration"
 require "thincloud/authentication/engine"
 require "thincloud/authentication/authenticatable_controller"
 require "thincloud/authentication/identifiable_user"

--- a/lib/thincloud/authentication/configuration.rb
+++ b/lib/thincloud/authentication/configuration.rb
@@ -1,0 +1,18 @@
+module Thincloud::Authentication
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Configuration.new
+    yield configuration
+  end
+
+  class Configuration
+    attr_accessor :providers
+
+    def initialize
+      @providers = {}
+    end
+  end
+end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,0 +1,25 @@
+require "minitest_helper"
+
+class Thincloud::Authentication::ConfigureTest < ActiveSupport::TestCase
+  setup do
+    Thincloud::Authentication.configure do |config|
+      config.providers[:linkedin] = {
+        scopes: "r_emailaddress r_basicprofile",
+        fields: ["id", "email-address", "first-name", "last-name", "headline",
+                 "industry", "picture-url", "location", "public-profile-url"]
+      }
+    end
+
+    @providers_hash = {
+      linkedin: {
+        scopes: "r_emailaddress r_basicprofile",
+        fields: ["id", "email-address", "first-name", "last-name", "headline",
+                 "industry", "picture-url", "location", "public-profile-url"]
+      }
+    }
+  end
+
+  test "options are assigned" do
+    assert_equal @providers_hash, Thincloud::Authentication.configuration.providers
+  end
+end

--- a/test/dummy/config/initializers/thincloud_authentication.rb
+++ b/test/dummy/config/initializers/thincloud_authentication.rb
@@ -1,0 +1,7 @@
+Thincloud::Authentication.configure do |config|
+  config.providers[:linkedin] = {
+    scopes: "r_emailaddress r_basicprofile",
+    fields: ["id", "email-address", "first-name", "last-name", "headline",
+             "industry", "picture-url", "location", "public-profile-url"]
+  }
+end

--- a/thincloud-authentication.gemspec
+++ b/thincloud-authentication.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rails", "~> 3.2.8"
   s.add_dependency "omniauth", "~> 1.1.1"
   s.add_dependency "omniauth-identity", "~> 1.1.0"
+  s.add_dependency "omniauth-linkedin", "~> 0.0.8"
 
   s.add_development_dependency "cane"
   s.add_development_dependency "guard"


### PR DESCRIPTION
This adds a `configure` method to the module to allow configuring additional OAuth providers. LinkedIn is currently the first additional supported strategy.
