### PR TITLE
break out module declarations:

### DIFF
--- a/lib/thincloud/authentication/configuration.rb
+++ b/lib/thincloud/authentication/configuration.rb
@@ -1,20 +1,22 @@
-module Thincloud::Authentication
-  class << self
-    attr_accessor :configuration
-  end
+module Thincloud
+  module Authentication
+    class << self
+      attr_accessor :configuration
+    end
 
-  def self.configure
-    self.configuration ||= Configuration.new
-    yield configuration
-  end
+    def self.configure
+      self.configuration ||= Configuration.new
+      yield configuration
+    end
 
-  # Public: Configuration options for the Thincloud::Authentication module
-  class Configuration
-    attr_accessor :providers, :mailer_sender
+    # Public: Configuration options for the Thincloud::Authentication module
+    class Configuration
+      attr_accessor :providers, :mailer_sender
 
-    def initialize
-      @providers = {}
-      @mailer_sender = "app@example.com"
+      def initialize
+        @providers = {}
+        @mailer_sender = "app@example.com"
+      end
     end
   end
 end

--- a/lib/thincloud/authentication/identifiable_user.rb
+++ b/lib/thincloud/authentication/identifiable_user.rb
@@ -1,9 +1,11 @@
-module Thincloud::Authentication
-  module IdentifiableUser
-    extend ActiveSupport::Concern
+module Thincloud
+  module Authentication
+    module IdentifiableUser
+      extend ActiveSupport::Concern
 
-    included do
-      has_many :identities, class_name: "Thincloud::Authentication::Identity"
+      included do
+        has_many :identities, class_name: "Thincloud::Authentication::Identity"
+      end
     end
   end
 end


### PR DESCRIPTION
- I had an issue with including this gem on a 
  fresh rails application: uninitialized constant 
  Thincloud
- fix: be more explicit with module declarations
