### PR TITLE
Custom layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ The following must be true for `thincloud-authentication` to operate properly:
 The `Thincloud::Authentication` module accepts a `configure` block with options to customize the engine behavior.
 
 
+### Layouts
+
+Set the `layout` option to customize the layout used by all thincloud-authentication views:
+
+```ruby
+Thincloud::Authentication.configure do |config|
+  config.layout = "other"
+end
+
 ### Mailers
 
 Set the `mailer_sender` option to customize the "From" address of the emails sent from the system:

--- a/app/controllers/thincloud/authentication/application_controller.rb
+++ b/app/controllers/thincloud/authentication/application_controller.rb
@@ -1,6 +1,6 @@
 module Thincloud::Authentication
   # Public: Primary controller settings and helpers for the engine.
   class ApplicationController < ActionController::Base
-    layout "application"
+    layout Thincloud::Authentication.configuration.layout
   end
 end

--- a/lib/thincloud/authentication/configuration.rb
+++ b/lib/thincloud/authentication/configuration.rb
@@ -11,9 +11,10 @@ module Thincloud
 
     # Public: Configuration options for the Thincloud::Authentication module
     class Configuration
-      attr_accessor :providers, :mailer_sender
+      attr_accessor :layout, :providers, :mailer_sender
 
       def initialize
+        @layout = "application"
         @providers = {}
         @mailer_sender = "app@example.com"
       end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,25 +1,29 @@
 require "minitest_helper"
 
-class Thincloud::Authentication::ConfigureTest < ActiveSupport::TestCase
-  setup do
-    Thincloud::Authentication.configure do |config|
-      config.providers[:linkedin] = {
-        scopes: "r_emailaddress r_basicprofile",
-        fields: ["id", "email-address", "first-name", "last-name", "headline",
-                 "industry", "picture-url", "location", "public-profile-url"]
+describe Thincloud::Authentication::Configuration do
+
+  describe "provider" do
+    before do
+      Thincloud::Authentication.configure do |config|
+        config.providers[:linkedin] = {
+          scopes: "r_emailaddress r_basicprofile",
+          fields: ["id", "email-address", "first-name", "last-name", "headline",
+                   "industry", "picture-url", "location", "public-profile-url"]
+        }
+      end
+
+      @providers_hash = {
+        linkedin: {
+          scopes: "r_emailaddress r_basicprofile",
+          fields: ["id", "email-address", "first-name", "last-name", "headline",
+                   "industry", "picture-url", "location", "public-profile-url"]
+        }
       }
     end
 
-    @providers_hash = {
-      linkedin: {
-        scopes: "r_emailaddress r_basicprofile",
-        fields: ["id", "email-address", "first-name", "last-name", "headline",
-                 "industry", "picture-url", "location", "public-profile-url"]
-      }
-    }
+    it "options are assigned" do
+      Thincloud::Authentication.configuration.providers.must_equal @providers_hash
+    end
   end
 
-  test "options are assigned" do
-    assert_equal @providers_hash, Thincloud::Authentication.configuration.providers
-  end
 end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -2,6 +2,20 @@ require "minitest_helper"
 
 describe Thincloud::Authentication::Configuration do
 
+  describe "layout" do
+    it { Thincloud::Authentication.configuration.layout.must_equal "application" }
+
+    describe "with a custom layout" do
+      before do
+        Thincloud::Authentication.configure do |config|
+          config.layout = "other"
+        end
+      end
+
+      it { Thincloud::Authentication.configuration.layout.must_equal "other" }
+    end
+  end
+
   describe "provider" do
     before do
       Thincloud::Authentication.configure do |config|


### PR DESCRIPTION
Introduces custom layout support via the configuration block.
- Defaults to "application" layout as before, but accepts an alternate layout.
- Updated readme to include custom layout specification.
- Includes test examples for default and custom layout.
