### PR TITLE
Add methods for post login/registration redirects.

### DIFF
--- a/app/controllers/thincloud/authentication/registrations_controller.rb
+++ b/app/controllers/thincloud/authentication/registrations_controller.rb
@@ -33,7 +33,7 @@ module Thincloud::Authentication
           RegistrationsMailer.verification_token(@identity).deliver
           flash[:notice] = "Check your email to verify your registration."
         end
-        redirect_to main_app.root_url
+        redirect_to after_registration_path
       end
     end
 

--- a/app/controllers/thincloud/authentication/sessions_controller.rb
+++ b/app/controllers/thincloud/authentication/sessions_controller.rb
@@ -6,13 +6,13 @@ module Thincloud::Authentication
     before_filter :authenticate!, only: [:authenticated]
 
     def new
-      redirect_to main_app.root_url if logged_in?
+      redirect_to after_login_path if logged_in?
       @identity = Identity.new
     end
 
     def destroy
       logout
-      redirect_to main_app.root_url, notice: "You have been logged out."
+      redirect_to after_logout_path, notice: "You have been logged out."
     end
 
     def authenticated

--- a/lib/thincloud/authentication/authenticatable_controller.rb
+++ b/lib/thincloud/authentication/authenticatable_controller.rb
@@ -58,6 +58,27 @@ module Thincloud
         reset_session
       end
 
+      # Protected: Provides the URL to redirect to after logging in.
+      #
+      # Returns: A string.
+      def after_login_path
+        main_app.root_url
+      end
+
+      # Protected: Provides the URL to redirect to after logging out.
+      #
+      # Returns: A string.
+      def after_logout_path
+        main_app.root_url
+      end
+
+      # Protected: Provides the URL to redirect to after registering.
+      #
+      # Returns: A string.
+      def after_registration_path
+        main_app.root_url
+      end
+
     end
 
   end

--- a/test/controllers/thincloud/authentication/sessions_controller_test.rb
+++ b/test/controllers/thincloud/authentication/sessions_controller_test.rb
@@ -3,10 +3,22 @@ require "minitest_helper"
 module Thincloud::Authentication
   describe SessionsController do
     describe "GET new" do
-      before { get :new }
 
-      it { assert_response :success }
-      it { assert_template :new }
+      describe "when not logged in" do
+        before { get :new }
+
+        it { assert_response :success }
+        it { assert_template :new }
+      end
+
+      describe "when logged in" do
+        before do
+          SessionsController.any_instance.stubs(:logged_in?).returns(true)
+          get :new
+        end
+
+        it { assert_redirected_to "/" }
+      end
     end
 
     describe "DELETE destroy" do

--- a/test/controllers/thincloud/authentication/sessions_controller_test.rb
+++ b/test/controllers/thincloud/authentication/sessions_controller_test.rb
@@ -12,7 +12,7 @@ module Thincloud::Authentication
     describe "DELETE destroy" do
       before { delete :destroy }
 
-      it { assert_response :redirect }
+      it { assert_redirected_to "/" }
       it { flash[:notice].must_equal "You have been logged out." }
     end
 


### PR DESCRIPTION
Adds methods for post-login, post-logout and post-register paths.
- Paths default to root URL as they did before.
- A separate method is provided for each path for easy overriding.
