### PR TITLE
Resolve custom redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ You can customize the paths used to redirect users after login, logout, registra
 * `after_login_path` is used after the user logs in.
 * `after_logout_path` is used after the user logs out.
 * `after_registration_path` is used after the user registers.
-* `after_verify_path` is used after the user verifies their email.
+* `after_verification_path` is used after the user verifies their email.
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -140,12 +140,12 @@ Using the example above, you will have the following routes locally:
 
 ### Redirection
 
-You can customize the paths used to redirect users after login, logout and registration by overriding the corresponding methods in your ApplicationController, or specific controllers, as needed.
+You can customize the paths used to redirect users after login, logout, registration and email verification by overriding the corresponding methods in your ApplicationController, or specific controllers, as needed.
 
 * `after_login_path` is used after the user logs in.
 * `after_logout_path` is used after the user logs out.
 * `after_registration_path` is used after the user registers.
-
+* `after_verify_path` is used after the user verifies their email.
 
 ## TODO
 

--- a/app/controllers/thincloud/authentication/application_controller.rb
+++ b/app/controllers/thincloud/authentication/application_controller.rb
@@ -1,6 +1,0 @@
-module Thincloud::Authentication
-  # Public: Primary controller settings and helpers for the engine.
-  class ApplicationController < ActionController::Base
-    layout Thincloud::Authentication.configuration.layout
-  end
-end

--- a/app/controllers/thincloud/authentication/registrations_controller.rb
+++ b/app/controllers/thincloud/authentication/registrations_controller.rb
@@ -1,9 +1,9 @@
-require_dependency "thincloud/authentication/application_controller"
-
 module Thincloud::Authentication
   # Public: Handle OmniAuth callbacks.
   class RegistrationsController < ApplicationController
     before_filter :extract_identity, only: :create
+
+    layout Thincloud::Authentication.configuration.layout
 
     def new
       @identity = Identity.new

--- a/app/controllers/thincloud/authentication/registrations_controller.rb
+++ b/app/controllers/thincloud/authentication/registrations_controller.rb
@@ -42,7 +42,7 @@ module Thincloud::Authentication
     def verify
       identity = Identity.verify!(params[:token])
       login_as identity.user
-      redirect_to after_verify_path,
+      redirect_to after_verification_path,
         notice: "Thank you! Your registration has been verified."
     end
 

--- a/app/controllers/thincloud/authentication/registrations_controller.rb
+++ b/app/controllers/thincloud/authentication/registrations_controller.rb
@@ -15,11 +15,11 @@ module Thincloud::Authentication
       # identity exists
       if @identity.present?
         login_as @identity.user
-        redirect_to main_app.root_url, notice: "You have been logged in."
+        redirect_to after_registration_path, notice: "You have been logged in."
       # new identity for current_user
       elsif current_user
         add_omniauth_identity_to_current_user
-        redirect_to main_app.root_url, notice: "You have been logged in."
+        redirect_to after_registration_path, notice: "You have been logged in."
       # failed identity login
       elsif invalid_identity_credentials?
         redirect_to auth_failure_url message: "invalid_credentials",
@@ -42,7 +42,7 @@ module Thincloud::Authentication
     def verify
       identity = Identity.verify!(params[:token])
       login_as identity.user
-      redirect_to main_app.root_url,
+      redirect_to after_verify_path,
         notice: "Thank you! Your registration has been verified."
     end
 

--- a/app/controllers/thincloud/authentication/registrations_controller.rb
+++ b/app/controllers/thincloud/authentication/registrations_controller.rb
@@ -5,6 +5,8 @@ module Thincloud::Authentication
 
     layout Thincloud::Authentication.configuration.layout
 
+    helper "thincloud/authentication/registrations"
+
     def new
       @identity = Identity.new
     end

--- a/app/controllers/thincloud/authentication/registrations_controller.rb
+++ b/app/controllers/thincloud/authentication/registrations_controller.rb
@@ -15,11 +15,11 @@ module Thincloud::Authentication
       # identity exists
       if @identity.present?
         login_as @identity.user
-        redirect_to after_registration_path, notice: "You have been logged in."
+        redirect_to after_login_path, notice: "You have been logged in."
       # new identity for current_user
       elsif current_user
         add_omniauth_identity_to_current_user
-        redirect_to after_registration_path, notice: "You have been logged in."
+        redirect_to after_login_path, notice: "You have been logged in."
       # failed identity login
       elsif invalid_identity_credentials?
         redirect_to auth_failure_url message: "invalid_credentials",

--- a/app/controllers/thincloud/authentication/sessions_controller.rb
+++ b/app/controllers/thincloud/authentication/sessions_controller.rb
@@ -1,9 +1,9 @@
-require_dependency "thincloud/authentication/application_controller"
-
 module Thincloud::Authentication
   # Public: Handle login/logout behavior.
   class SessionsController < ApplicationController
     before_filter :authenticate!, only: [:authenticated]
+
+    layout Thincloud::Authentication.configuration.layout
 
     def new
       redirect_to after_login_path if logged_in?

--- a/app/controllers/thincloud/authentication/sessions_controller.rb
+++ b/app/controllers/thincloud/authentication/sessions_controller.rb
@@ -5,6 +5,8 @@ module Thincloud::Authentication
 
     layout Thincloud::Authentication.configuration.layout
 
+    helper "thincloud/authentication/registrations"
+
     def new
       redirect_to after_login_path if logged_in?
       @identity = Identity.new

--- a/lib/thincloud/authentication/authenticatable_controller.rb
+++ b/lib/thincloud/authentication/authenticatable_controller.rb
@@ -79,10 +79,10 @@ module Thincloud
         main_app.root_url
       end
 
-      # Protected: Provides the URL to redirect to after verifying.
+      # Protected: Provides the URL to redirect to after verification.
       #
       # Returns: A string.
-      def after_verify_path
+      def after_verification_path
         main_app.root_url
       end
 

--- a/lib/thincloud/authentication/authenticatable_controller.rb
+++ b/lib/thincloud/authentication/authenticatable_controller.rb
@@ -79,6 +79,14 @@ module Thincloud
         main_app.root_url
       end
 
+      # Protected: Provides the URL to redirect to after verifying.
+      #
+      # Returns: A string.
+      def after_verify_path
+        main_app.root_url
+      end
+
+
     end
 
   end


### PR DESCRIPTION
- Add after_verification_path method consistent with #10.
- Assign proper redirection paths in registrations controller.
- Remove application_controller to avoid `require_dependency` issue preventing `thincloud-authentication`'s controllers from utilizing overridden custom redirection methods defined at the application level.
- Reviewed with @bousquet, @phlipper and @sean-j-williamson.
- Closes #13 (which would have solved the same problem, but with Configuration settings vs. instance methods).
