### PR TITLE
Invalid auth issue

### DIFF
--- a/app/models/thincloud/authentication/identity.rb
+++ b/app/models/thincloud/authentication/identity.rb
@@ -30,7 +30,9 @@ module Thincloud::Authentication
     #
     # Returns: An instance of `Identity` or `nil`.
     def self.find_omniauth(omniauth)
-      find_by_provider_and_uid omniauth["provider"], omniauth["uid"]
+      if omniauth["uid"].present?
+        find_by_provider_and_uid omniauth["provider"], omniauth["uid"]
+      end
     end
 
     # Public: Mark the `Identity` as having been verified.

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,6 +1,21 @@
 require "minitest_helper"
 
 describe Thincloud::Authentication::Configuration do
+  let(:config) { Thincloud::Authentication::Configuration.new }
+
+  it { config.must_be_kind_of Thincloud::Authentication::Configuration }
+  it { config.must_respond_to :layout }
+  it { config.must_respond_to :layout= }
+  it { config.must_respond_to :providers }
+  it { config.must_respond_to :providers= }
+  it { config.must_respond_to :mailer_sender }
+  it { config.must_respond_to :mailer_sender= }
+
+  describe "defaults" do
+    it { config.layout.must_equal "application" }
+    it { config.providers.must_equal Hash.new }
+    it { config.mailer_sender.must_equal "app@example.com" }
+  end
 
   describe "layout" do
     it { Thincloud::Authentication.configuration.layout.must_equal "application" }

--- a/test/models/identity_test.rb
+++ b/test/models/identity_test.rb
@@ -16,15 +16,41 @@ module Thincloud::Authentication
     it { identity.must_respond_to(:verified_at) }
 
     describe "self.find_omniauth(omniauth)" do
-      let(:auth_hash) do
-        OmniAuth::AuthHash.new(provider: "identity", uid: "123")
+      describe "with valid uid" do
+        let(:auth_hash) do
+          OmniAuth::AuthHash.new(provider: "identity", uid: "123")
+        end
+
+        before do
+          Identity.expects(:find_by_provider_and_uid).with("identity", "123")
+        end
+
+        it { Identity.find_omniauth(auth_hash) }
       end
 
-      before do
-        Identity.expects(:find_by_provider_and_uid).with("identity", "123")
+      describe "with nil uid" do
+        let(:auth_hash) do
+          OmniAuth::AuthHash.new(provider: "identity", uid: nil)
+        end
+
+        before do
+          Identity.expects(:find_by_provider_and_uid).never
+        end
+
+        it { Identity.find_omniauth(auth_hash).must_be_nil }
       end
 
-      it { Identity.find_omniauth(auth_hash) }
+      describe "with empty uid" do
+        let(:auth_hash) do
+          OmniAuth::AuthHash.new(provider: "identity", uid: "")
+        end
+
+        before do
+          Identity.expects(:find_by_provider_and_uid).never
+        end
+
+        it { Identity.find_omniauth(auth_hash).must_be_nil }
+      end
     end
 
     describe "self.verify!(token)" do


### PR DESCRIPTION
In some cases, where Users and Identities are 
manually created, we will have these records in 
the system without a valid UID. This presents a
problem with logging in as the #create method
of RegistrationsController ends up calling
`Identity.find_omniauth` which will find an 
identity - which is invalid. 

By checking for a missing uid we return a nil
from `find_omniauth` which allows the rest of
the logic to take over.

P.S. There are tests for this.
