### PR TITLE
Rails 4 Compatibility

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Thincloud::Authentication::Engine.routes.draw do
-  match ":provider/callback" => "registrations#create", as: "auth_callback"
+  post ":provider/callback", to: "registrations#create", as: "auth_callback"
   get "failure", to: "sessions#new", as: "auth_failure"
 
   get "login", to: "sessions#new", as: "login"


### PR DESCRIPTION
- Rails 4 doesn't allow use of plain `match` anymore, instead requiring explicit HTTP verb definition.
