### PR TITLE
Project Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ test/dummy/tmp/
 test/dummy/.sass-cache
 coverage/
 .rbx/
+bin/
+vendor/bundle/

--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+thincloud-authentication

--- a/.ruby-version
+++ b/.ruby-version
@@ -1,1 +1,1 @@
-1.9.3@thincloud-authentication
+ruby-1.9.3

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,10 +1,12 @@
 if RUBY_ENGINE == "ruby"
   begin
     require "simplecov"
-    SimpleCov.add_filter "test"
-    SimpleCov.add_filter "config"
-    SimpleCov.command_name "MiniTest"
-    SimpleCov.start
+    SimpleCov.start "rails" do
+      add_filter "test"
+      add_filter "config"
+      add_filter "vendor"
+      command_name "MiniTest"
+    end
   rescue LoadError
     warn "unable to load SimpleCov"
   end


### PR DESCRIPTION
- split `.ruby-version` and `.ruby-gemset` files
- add Bundler artifacts to `.gitignore`
- ignore Bundler directories for SimpleCov
