### PR TITLE
explicitly require dependencies:

### DIFF
--- a/lib/thincloud/authentication/engine.rb
+++ b/lib/thincloud/authentication/engine.rb
@@ -1,3 +1,6 @@
+require "rails"
+require "strong_parameters"
+
 module Thincloud
   module Authentication
 


### PR DESCRIPTION
- this prevents the need to have strong_parameters
  listed in the Gemfile even though it comes along
  as a dependency with this gem.
