### PR TITLE
use signed cookies directly vs. accessing session:

### DIFF
--- a/lib/thincloud/authentication/authenticatable_controller.rb
+++ b/lib/thincloud/authentication/authenticatable_controller.rb
@@ -17,8 +17,8 @@ module Thincloud
       #
       # Returns: An instance of `User` or `nil`.
       def current_user
-        return nil if session[:uid].blank?
-        @current_user ||= User.find(session[:uid])
+        return nil if cookies.signed[:uid].blank?
+        @current_user ||= User.find(cookies.signed[:uid])
       end
 
       # Protected:  Determine if the current request has a logged in user.
@@ -48,7 +48,11 @@ module Thincloud
       # Returns: The `id` of the provided user.
       def login_as(user)
         reset_session  # avoid session fixation
-        session[:uid] = user.id
+        cookies.signed[:uid] = {
+          value: user.id,
+          secure: request.ssl?,
+          httponly: true
+        }
       end
 
       # Protected: Clear the session of an authenticated user.
@@ -56,6 +60,7 @@ module Thincloud
       # Returns: A new empty session instance.
       def logout
         reset_session
+        cookies.delete(:uid)
       end
 
       # Protected: Provides the URL to redirect to after logging in.

--- a/test/controllers/thincloud/authentication/registrations_controller_test.rb
+++ b/test/controllers/thincloud/authentication/registrations_controller_test.rb
@@ -41,7 +41,7 @@ module Thincloud::Authentication
           post :create
         end
 
-        it { session[:uid].wont_be_nil }
+        it { cookies.signed[:uid].must_equal user.id }
         it { assert_response :redirect }
         it { assert_redirected_to "/" }
         it { flash[:notice].must_equal "You have been logged in." }
@@ -110,7 +110,7 @@ module Thincloud::Authentication
 
           it { assert_response :redirect }
           it { assert_redirected_to "/" }
-          it { session[:uid].must_be_nil }
+          it { cookies.signed[:uid].must_be_nil }
           it { flash[:notice].must_equal "Check your email to verify your registration." }
           it { User.count.must_equal 1 }
           it { Identity.count.must_equal 1 }
@@ -138,7 +138,7 @@ module Thincloud::Authentication
 
           it { assert_response :redirect }
           it { assert_redirected_to "/" }
-          it { session[:uid].must_equal assigns[:identity].user.id }
+          it { cookies.signed[:uid].must_equal assigns[:identity].user.id }
           it { flash[:alert].must_be_nil }
           it { User.count.must_equal 1 }
           it { Identity.count.must_equal 1 }

--- a/test/controllers/thincloud/authentication/sessions_controller_test.rb
+++ b/test/controllers/thincloud/authentication/sessions_controller_test.rb
@@ -9,6 +9,7 @@ module Thincloud::Authentication
 
         it { assert_response :success }
         it { assert_template :new }
+        it { cookies.signed[:uid].must_be_nil }
       end
 
       describe "when logged in" do
@@ -26,6 +27,7 @@ module Thincloud::Authentication
 
       it { assert_redirected_to "/" }
       it { flash[:notice].must_equal "You have been logged out." }
+      it { cookies.signed[:uid].must_be_nil }
     end
 
     describe "GET authenticated" do
@@ -40,7 +42,7 @@ module Thincloud::Authentication
       describe "logged in" do
         before do
           User.stubs(:find).with(123).returns(User.new)
-          session[:uid] = 123
+          cookies.signed[:uid] = 123
           get :authenticated
         end
 


### PR DESCRIPTION
- this addresses an issue where certain session
  stores would not logout properly via the
  `reset_session` call.
