### PR TITLE
Revise password requirement logic

### DIFF
--- a/app/models/thincloud/authentication/identity.rb
+++ b/app/models/thincloud/authentication/identity.rb
@@ -102,7 +102,7 @@ module Thincloud::Authentication
     #
     # Returns: true or false
     def password_required?
-      identity_provider? && password_reset_token.blank?
+      identity_provider? && (!password.nil? || !password_confirmation.nil?)
     end
   end
 end

--- a/test/models/identity_test.rb
+++ b/test/models/identity_test.rb
@@ -9,11 +9,19 @@ module Thincloud::Authentication
     it { identity.must allow_value("foo@bar.com").for(:email) }
     it { identity.wont allow_value("foo").for(:email) }
     it { identity.must validate_presence_of(:password_digest) }
-    it { identity.must validate_confirmation_of(:password) }
     it { identity.must_respond_to(:verification_token) }
     it { identity.verification_token.wont_be_nil }
     it { identity.verification_token.must_match /[\w\-]{22}/ }
     it { identity.must_respond_to(:verified_at) }
+
+    describe "validations for password fields" do
+      describe "when password is required" do
+        before { identity.stubs(:password_required?).returns(true) }
+
+        it { identity.must validate_presence_of(:password) }
+        it { identity.must validate_confirmation_of(:password) }
+      end
+    end
 
     describe "self.find_omniauth(omniauth)" do
       describe "with valid uid" do
@@ -116,6 +124,31 @@ module Thincloud::Authentication
         identity.generate_password_token!
         identity.password_reset_token.wont_be_nil
         identity.password_reset_sent_at.wont_be_nil
+      end
+    end
+
+    describe "#password_required?" do
+      describe "when provider is identity" do
+        before { identity.expects(:identity_provider?).returns(true) }
+
+        describe "with password provided" do
+          before { identity.password = "abc123" }
+          it     { identity.password_required?.must_equal true }
+        end
+
+        describe "with password confirmation provided" do
+          before { identity.password_confirmation = "abc123" }
+          it     { identity.password_required?.must_equal true }
+        end
+
+        describe "without password or confirmation provided" do
+          it { identity.password_required?.must_equal false }
+        end
+      end
+
+      describe "when provider is not identity" do
+        before { identity.expects(:identity_provider?).returns(false) }
+        it     { identity.password_required?.must_equal false }
       end
     end
   end


### PR DESCRIPTION
- Continues to only require password when provider
  is identity.
- Continues to require password fields be 
  completed during password reset process.
- Bases password requirement on assignment of
  password or password_confirmation values rather
  than on blankness of password reset token, fixing
  issue where Identity#verify! was failing to save
  because password values were being expected.

Closes #39 
